### PR TITLE
API versioning

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -131,3 +131,8 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, '..', 'mediaroot')
+
+REST_FRAMEWORK = {
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
+    'DEFAULT_VERSION': 'pre1',
+}

--- a/src/harrastuspassi/harrastuspassi/urls.py
+++ b/src/harrastuspassi/harrastuspassi/urls.py
@@ -1,7 +1,7 @@
 
 # -*- coding: utf-8 -*-
 
-from django.urls import path, include
+from django.urls import include, path, re_path
 from rest_framework import routers
 from harrastuspassi.api import HobbyViewSet, HobbyCategoryViewSet, HobbyEventViewSet
 
@@ -12,11 +12,13 @@ router.register(r'hobbyevents', HobbyEventViewSet)
 
 
 public_urlpatterns = [
-    path('api/', include(router.urls)),
+    re_path('api/(?P<version>(pre1))/', include(router.urls,)),
+    path('api/', include(router.urls)),  # DEPRECATED, used by mobile v0.2.0
 ]
 
 internal_urlpatterns = [
-    path('mobile-api/', include(router.urls)),
+    re_path('mobile-api/(?P<version>(pre1))/', include(router.urls)),
+    path('mobile-api/', include(router.urls)),  # DEPRECATED, used by mobile v0.2.0
 ]
 
 urlpatterns = public_urlpatterns + internal_urlpatterns


### PR DESCRIPTION
Closes #10 

Support for URL based API versioning. First version is `pre1`.
    
API version is part of the URL specification. The unversioned API url is
still provided, the default version for that is configured in project
settings.
    
Version checks in code are done like `if request.version == 'pre1'`. The
intention is that breaking changes are coded as the default path and old
functionality is provided with conditionals, deprecated and removed quickly
in the release cycle. Deprecated code should be clearly commented as
follows: `# DEPRECATED, used by mobile v0.2.0`.
