### PR TITLE
Add CORS headers for development configuration only

### DIFF
--- a/project/development.py
+++ b/project/development.py
@@ -10,6 +10,13 @@ from project.settings import *  # noqa
 DEBUG = True
 TEMPLATE_DEBUG = True
 
+# CORS headers for local development
+INSTALLED_APPS += ('corsheaders',)
+MIDDLEWARE = ['corsheaders.middleware.CorsMiddleware'] + MIDDLEWARE
+CORS_ORIGIN_ALLOW_ALL = False
+CORS_ORIGIN_WHITELIST = ['http://localhost:3000']
+CORS_ALLOW_CREDENTIALS = True
+
 # Compress
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ astroid==2.2.5
 atomicwrites==1.3.0
 attrs==19.1.0
 codecov==2.0.15
+django-cors-headers==3.1.0
 dodgy==0.1.9
 flake8==3.7.8
 freezegun==0.3.12


### PR DESCRIPTION
CORS headers are generated by Django only for development configuration.

In production we might have the web server generate CORS headers. Or we might decide to use this code production as well.