### PR TITLE
Exclude past events from HobbyEvents and Promotions

### DIFF
--- a/src/harrastuspassi/harrastuspassi/api.py
+++ b/src/harrastuspassi/harrastuspassi/api.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import datetime
 import logging
 from collections import defaultdict
 from functools import wraps
 from itertools import chain
 
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
 from django_filters import rest_framework as filters
@@ -273,11 +275,21 @@ class HobbyEventFilter(filters.FilterSet):
                                                  label=_(f'Return results with starting date in given weekday.'
                                                          f' Enter a number from 1 to 7. Use ISO 8601 weekdays:'
                                                          f' 1=Monday, 7=Sunday.'))
+    exclude_past_events = filters.BooleanFilter(method='filter_past_events', label=_('Show upcoming only'))
 
     class Meta:
         model = HobbyEvent
         fields = ['category', 'hobby', 'start_date_from', 'start_date_to',
                   'start_time_from', 'start_time_to', 'start_weekday']
+
+    def filter_past_events(self, queryset, name, value):
+        is_filtering_requested = value
+        date_is_before_today = Q(end_date__lt=datetime.date.today())
+        date_is_today_but_time_is_in_past = Q(end_date=datetime.date.today()) & Q(end_time__lt=datetime.datetime.now().time())
+        if is_filtering_requested:
+            return queryset.exclude(date_is_before_today | date_is_today_but_time_is_in_past)
+        else:
+            return queryset
 
 
 class HobbyEventViewSet(viewsets.ModelViewSet):
@@ -308,9 +320,24 @@ class LocationViewSet(viewsets.ModelViewSet):
         return self.serializer_class
 
 
+class PromotionFilter(filters.FilterSet):
+    exclude_past_events = filters.BooleanFilter(method='filter_past_events', label=_('Show upcoming only'))
+
+    def filter_past_events(self, queryset, name, value):
+        is_filtering_requested = value
+        date_is_before_today = Q(end_date__lt=datetime.date.today())
+        date_is_today_but_time_is_in_past = Q(end_date=datetime.date.today()) & Q(end_time__lt=datetime.datetime.now().time())
+        if is_filtering_requested:
+            return queryset.exclude(date_is_before_today | date_is_today_but_time_is_in_past)
+        else:
+            return queryset
+
+
 class PromotionViewSet(viewsets.ModelViewSet):
     queryset = Promotion.objects.all()
     serializer_class = PromotionSerializer
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = PromotionFilter
 
     def perform_create(self, serializer):
         municipality = Municipality.get_current_municipality_for_moderator(self.request.user)

--- a/src/harrastuspassi/harrastuspassi/tests/conftest.py
+++ b/src/harrastuspassi/harrastuspassi/tests/conftest.py
@@ -16,6 +16,7 @@ from harrastuspassi.models import (
 )
 
 FROZEN_DATE = '2022-2-22'
+FROZEN_DATETIME = '2022-2-22 16:00:00'
 
 
 @pytest.fixture

--- a/src/harrastuspassi/harrastuspassi/tests/test_promotion_benefit_api.py
+++ b/src/harrastuspassi/harrastuspassi/tests/test_promotion_benefit_api.py
@@ -1,7 +1,10 @@
+import datetime
 import pytest
 from django.core.exceptions import ValidationError
 from django.urls import reverse
+from freezegun import freeze_time
 from harrastuspassi.models import Benefit, Promotion
+from harrastuspassi.tests.conftest import FROZEN_DATE, FROZEN_DATETIME
 
 
 @pytest.mark.django_db
@@ -58,3 +61,44 @@ def test_benefit_api_authenticated_user(user_api_client, valid_benefit_data):
     url = reverse('benefit-list')
     response = user_api_client.post(url, data=valid_benefit_data, format='json')
     assert response.status_code == 201
+
+
+@freeze_time(FROZEN_DATETIME)
+@pytest.mark.django_db
+def test_list_promotions_exclude_past_events(api_client, organizer, location):
+    api_url = reverse('promotion-list')
+    url = f'{api_url}?exclude_past_events=true'
+    Promotion.objects.all().delete()
+    date_today = datetime.datetime.strptime(FROZEN_DATE, '%Y-%m-%d').date()
+
+    # event ends after a week from now, should be returned from API
+    test_event = Promotion.objects.create(
+        name='Test promotion',
+        description='Hello this is valid test promotion',
+        start_date=FROZEN_DATE,
+        start_time='10:00',
+        end_date=date_today + datetime.timedelta(days=7),
+        end_time='15:59',
+        organizer=organizer,
+        available_count=10,
+        used_count=0,
+        location=location
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == 1
+
+    # event ended a minute ago, should not be returned from API
+    test_event.end_date = date_today
+    test_event.save()
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == 0
+
+    # event's end_time is after time now, but date is before
+    test_event.end_date = date_today - datetime.timedelta(days=1)
+    test_event.end_time = datetime.datetime.strptime('22:00', '%H:%M').time()
+    test_event.save()
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == 0


### PR DESCRIPTION
Closes #63 

Exclude past events from HobbyEvents and Promotions. This works with a url param `exclude_past_events=true`. Tests are included.