### PR TITLE
filter promotions by location

### DIFF
--- a/src/harrastuspassi/harrastuspassi/api.py
+++ b/src/harrastuspassi/harrastuspassi/api.py
@@ -383,6 +383,18 @@ class PromotionFilter(filters.FilterSet):
     exclude_past_events = filters.BooleanFilter(method='filter_past_events', label=_('Show upcoming only'))
     usable_only = filters.BooleanFilter(method='filter_used_promotions', label=_('Show only usable promotions'))
     editable_only = filters.BooleanFilter(method='filter_editable', label=_('Show editable only'))
+    ordering = NearestOrderingFilter(
+        fields=(
+            # (field name, param name)
+            ('distance_to_point', 'nearest'),
+        ),
+        field_labels={
+            'distance_to_point': _('Nearest'),
+        },
+        label=_('Ordering. Choices: `nearest`')
+    )
+    near_latitude = dummy_filter(filters.NumberFilter(label=_('Near latitude. This field is required when `nearest` ordering is used.')))
+    near_longitude = dummy_filter(filters.NumberFilter(label=_('Near longitude. This field is required when `nearest` ordering is used.')))
 
     def filter_past_events(self, queryset, name, value):
         is_filtering_requested = value

--- a/src/harrastuspassi/harrastuspassi/models.py
+++ b/src/harrastuspassi/harrastuspassi/models.py
@@ -190,6 +190,10 @@ class HobbyEventQuerySet(DistanceMixin, models.QuerySet):
     coordinates_field = 'hobby__location__coordinates'
 
 
+class PromotionQuerySet(DistanceMixin, models.QuerySet):
+    coordinates_field = 'location__coordinates'
+
+
 class HobbyEvent(ExternalDataModel, TimestampedModel):
     """ An event in time when a hobby takes place """
     DAY_OF_WEEK_CHOICES = (
@@ -247,6 +251,8 @@ class Promotion(TimestampedModel):
     used_count = models.PositiveIntegerField(default=0)
     location = models.ForeignKey(Location, on_delete=models.CASCADE)
     created_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.SET_NULL)
+    
+    objects = PromotionQuerySet.as_manager()
 
     def __str__(self):
         return self.name

--- a/src/harrastuspassi/harrastuspassi/tests/conftest.py
+++ b/src/harrastuspassi/harrastuspassi/tests/conftest.py
@@ -73,6 +73,12 @@ def frozen_date():
 
 
 @pytest.fixture
+def frozen_date_plus_year():
+    year, month, day = map(int, FROZEN_DATE.split('-'))
+    return datetime.date(year=year, month=month, day=day) + datetime.timedelta(365)
+
+
+@pytest.fixture
 def location(municipality):
     return Location.objects.create(name='Tampere', municipality=municipality)
 
@@ -101,6 +107,7 @@ def hobbyevent(hobby):
         start_time=datetime.datetime.strptime('09:00', '%H:%M').time(),
         end_time=datetime.datetime.strptime('10:30', '%H:%M').time()
     )
+
 
 @pytest.fixture
 def hobby2(location, organizer, municipality):
@@ -299,3 +306,39 @@ def hobby_near_with_events(hobby_near, frozen_date):
     HobbyEvent.objects.create(hobby=hobby_near, start_date=another_date, start_time='18:00',
                               end_date=another_date, end_time='19:00')
     return hobby_near
+
+
+@pytest.fixture
+def promotion_far(location_far, organizer, frozen_date):
+    return Promotion.objects.create(name='Test Promotion at farland',
+                                    available_count=100,
+                                    location=location_far,
+                                    organizer=organizer,
+                                    start_date=frozen_date,
+                                    start_time='00:00',
+                                    end_date=frozen_date + datetime.timedelta(365),
+                                    end_time='00:00')
+
+
+@pytest.fixture
+def promotion_midway(location_midway, organizer, frozen_date):
+    return Promotion.objects.create(name='Test Promotion at midland',
+                                    available_count=100,
+                                    location=location_midway,
+                                    organizer=organizer,
+                                    start_date=frozen_date,
+                                    start_time='00:00',
+                                    end_date=frozen_date + datetime.timedelta(365),
+                                    end_time='00:00')
+
+
+@pytest.fixture
+def promotion_near(location_near, organizer, frozen_date):
+    return Promotion.objects.create(name='Test Promotion at nearland',
+                                    available_count=100,
+                                    location=location_near,
+                                    organizer=organizer,
+                                    start_date=frozen_date,
+                                    start_time='00:00',
+                                    end_date=frozen_date + datetime.timedelta(365),
+                                    end_time='00:00')

--- a/src/harrastuspassi/harrastuspassi/tests/test_promotion_benefit_api.py
+++ b/src/harrastuspassi/harrastuspassi/tests/test_promotion_benefit_api.py
@@ -1,6 +1,5 @@
 import datetime
 import pytest
-from django.core.exceptions import ValidationError
 from django.urls import reverse
 from freezegun import freeze_time
 from harrastuspassi.models import Benefit, Promotion
@@ -171,3 +170,20 @@ def test_promotion_search_filter(api_client, organizer, location):
     assert response.status_code == 200
     assert test_promotion.id == response.data[0]['id']
     assert len(response.data) == 1
+
+
+@pytest.mark.django_db
+def test_promotions_location(api_client,
+                             promotion_far,
+                             promotion_midway,
+                             promotion_near):
+
+    """ Promotions should be orderable by distance to a point """
+    api_url = reverse('promotion-list')
+    url = f'{api_url}?ordering=nearest&near_latitude=1.00000&near_longitude=1.00000'
+    response = api_client.get(url)
+    assert response.status_code == 200
+    promotions = response.json()
+    assert promotion_near.pk == promotions[0]['id']
+    assert promotion_midway.pk == promotions[1]['id']
+    assert promotion_far.pk == promotions[2]['id']


### PR DESCRIPTION
This PR adds filtering Promotions by location. The implementation is based on the way filtering by location is currently implemented for Hobbies.

As with Hobbies the 'nearest' parameter should be added to the request in order to enable filtering. 
`?ordering=nearest&near_latitude=1.00000&near_longitude=1.00000`