### PR TITLE
Translated category search

### DIFF
--- a/src/harrastuspassi/harrastuspassi/api.py
+++ b/src/harrastuspassi/harrastuspassi/api.py
@@ -331,7 +331,7 @@ class HobbyEventViewSet(viewsets.ModelViewSet):
     serializer_class = HobbyEventSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     pagination_class = DefaultPagination
-    search_fields = ['hobby__name', 'hobby__description', 'hobby__categories__name']
+    search_fields = ['hobby__name', 'hobby__description', 'hobby__categories__name_fi', 'hobby__categories__name_en', 'hobby__categories__name_sv']
 
     @property
     def paginator(self):

--- a/src/harrastuspassi/harrastuspassi/tests/test_hobby_events_api.py
+++ b/src/harrastuspassi/harrastuspassi/tests/test_hobby_events_api.py
@@ -257,7 +257,9 @@ def test_hobby_event_text_search(
     date_today = datetime.datetime.strptime(FROZEN_DATE, '%Y-%m-%d').date()
     api_url = reverse('hobbyevent-list')
     test_hobby_category = HobbyCategory.objects.create(
-        name='Saappaanheitto'
+        name_fi='Saappaanheitto',
+        name_en='Boot throwing',
+        name_sv='Startkast'
     )
     test_hobby = Hobby.objects.create(
         name='Lorem ipsum dolor sit amet',
@@ -288,8 +290,22 @@ def test_hobby_event_text_search(
     assert test_hobby.id == response.data[0]['hobby']
     assert test_event.id == response.data[0]['id']
 
-    # Test searching by category
+    # Test searching by category name_fi
     url = f'{api_url}?search=saappaan'
+    response = api_client.get(url)
+    assert len(response.data) == 1
+    assert test_hobby.id == response.data[0]['hobby']
+    assert test_event.id == response.data[0]['id']
+
+    # Test searching by category name_en
+    url = f'{api_url}?search=boot'
+    response = api_client.get(url)
+    assert len(response.data) == 1
+    assert test_hobby.id == response.data[0]['hobby']
+    assert test_event.id == response.data[0]['id']
+
+    # Test searching by category name_sv
+    url = f'{api_url}?search=star'
     response = api_client.get(url)
     assert len(response.data) == 1
     assert test_hobby.id == response.data[0]['hobby']


### PR DESCRIPTION
Support translated `HobbyCategory` fields in `HobbyEvent` search filter