### PR TITLE
add django debug toolbar

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -7,6 +7,8 @@ from datetime import timedelta
 # Core configuration
 #
 
+DEBUG = os.environ.get('DEBUG', False)
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', '')
@@ -24,12 +26,12 @@ INSTALLED_APPS = [
     'health_check.storage',
 
     'django_filters',
+    'django_extensions',
     'guardian',
     'mptt',
     'rest_framework',
     'rest_framework_gis',
     'rest_framework.authtoken',
-
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -51,6 +53,11 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+if DEBUG:
+    INSTALLED_APPS.append('debug_toolbar')
+    MIDDLEWARE.insert(2, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+    INTERNAL_IPS = ['127.0.0.1']
 
 TEMPLATES = [
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ atomicwrites==1.3.0
 attrs==19.1.0
 codecov==2.0.15
 django-cors-headers==3.1.0
+django-debug-toolbar==2.2
+django-extensions==2.2.9
 dodgy==0.1.9
 flake8==3.7.8
 freezegun==0.3.12
@@ -40,5 +42,6 @@ snowballstemmer==1.9.0
 sqlparse==0.3.0
 typed-ast==1.4.0
 wcwidth==0.1.7
+Werkzeug==1.0.1
 wrapt==1.11.2
 zipp==0.5.2

--- a/src/harrastuspassi/harrastuspassi/urls/api.py
+++ b/src/harrastuspassi/harrastuspassi/urls/api.py
@@ -1,6 +1,6 @@
 
 # -*- coding: utf-8 -*-
-
+import debug_toolbar
 from django.urls import include, path, re_path
 from rest_framework import routers
 from harrastuspassi.api import (
@@ -31,6 +31,8 @@ public_urlpatterns = [
 internal_urlpatterns = [
     re_path('mobile-api/(?P<version>(pre1|pre2|v1))/', include(router.urls)),
     path('mobile-api/', include(router.urls)),  # DEPRECATED, used by mobile v0.2.0
+    path('__debug__/', include(debug_toolbar.urls))
 ]
+
 
 urlpatterns = public_urlpatterns + internal_urlpatterns


### PR DESCRIPTION
This PR adds django debug toolbar, django_extensions and Werkzeug which might simplify the development. To enjoy the benefits run `shell_plus` and `runserver_plus` in place of `shell` and `runserver`. However, convenience of these tools is of course a subjective thing, so I would totally understand if you didn't want them in the repo.