### PR TITLE
map fields to description and change location treatment

### DIFF
--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -1,5 +1,6 @@
 -e ./src/harrastuspassi
 
+beautifulsoup4==4.9.1
 coreapi==2.3.3
 django==2.2.4
 django-extra-fields==2.0.1

--- a/src/harrastuspassi/harrastuspassi/tests/test_linkedcourses_importer.py
+++ b/src/harrastuspassi/harrastuspassi/tests/test_linkedcourses_importer.py
@@ -125,3 +125,25 @@ def test_price_import(basic_event):
     assert command.get_price(event) == Decimal(10)
     event['offers'] = [{'price': {'fi': 'Vapaa pÄÄsy!'}}]
     assert command.get_price(event) == Decimal(0)
+
+
+@pytest.mark.django_db
+def test_description_import(basic_event):
+    command = LinkedCoursesImportCommand()
+    event = basic_event
+    event['short_description'] = {'fi': 'Short description'}
+    event['description'] = {'fi': '<p>Poesian ja Runokuun yhteisillassa.</p><p>Ovet klo 19:00.<br>htumaan.</p><p>Esiintyjät: </p>'}  # noqa: E501
+    event['offers'] = [{'info_url': {'fi': 'https://ticketshere.info'}, 'description': {'fi': 'Offers description.'}}]
+    assert command.get_description(event) == 'Short description Offer: Offers description. Tickets: https://ticketshere.info'  # noqa: E501
+    event['short_description'] = {'fi': ''}
+    assert command.get_description(event) == 'Offer: Offers description. Tickets: https://ticketshere.info Poesian ja Runokuun yhteisillassa.Ovet klo 19:00.htumaan.Esiintyjät:  '  # noqa: E501
+    event['short_description'] = 'null'
+    assert command.get_description(event) == 'Offer: Offers description. Tickets: https://ticketshere.info Poesian ja Runokuun yhteisillassa.Ovet klo 19:00.htumaan.Esiintyjät:  '  # noqa: E501
+    event['offers'] = [{'info_url': 'null', 'description': {'fi': 'Offers description.'}}]
+    assert command.get_description(event) == 'Offer: Offers description. Poesian ja Runokuun yhteisillassa.Ovet klo 19:00.htumaan.Esiintyjät: '  # noqa: E501
+    event['offers'] = [{'info_url': 'null', 'description': 'null'}]
+    assert command.get_description(event) == 'Poesian ja Runokuun yhteisillassa.Ovet klo 19:00.htumaan.Esiintyjät: '
+    event['offers'] = []
+    assert command.get_description(event) == 'Poesian ja Runokuun yhteisillassa.Ovet klo 19:00.htumaan.Esiintyjät: '
+    event['short_description'] = {'en': 'Short description'}
+    assert command.get_description(event) == 'Poesian ja Runokuun yhteisillassa.Ovet klo 19:00.htumaan.Esiintyjät: '


### PR DESCRIPTION
This PR adds mapping of description field to HP hobby description field in case short_description is absent and as well adds changes in location treatment that allows import from linkedevents.